### PR TITLE
fix image type in help to png.

### DIFF
--- a/camera/camera.html
+++ b/camera/camera.html
@@ -25,7 +25,7 @@
         <li>Add the camera node to your flow</li>
         <li>Click the <code>button</code> capture an image from the webcam</li>
     </ol>
-    <p>The <code>jpg</code> image is sent as the <code>msg.payload</code> object</p>
+    <p>The <code>png</code> image is sent as the <code>msg.payload</code> object</p>
     <p>Supported browsers</p>
     <ul>
       <li>Chrome</li>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-browser-utils",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A collection of Node-RED nodes for browser interaction",
   "dependencies": {
     "node-red-contrib-play-audio": "2.0.x",
@@ -19,7 +19,6 @@
     "type": "git",
     "url": "https://github.com/ibm-early-programs/node-red-contrib-browser-utils"
   },
-  "license": "Apache-2.0",
   "contributors": [
     {
       "name": "Chris Parsons",


### PR DESCRIPTION
canvas.toBlob default format is png. I tested on Firefox 49.0.2 and Chrome 54.0.2840.99 m on Windows.